### PR TITLE
Mark rst extension as text file

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const VERSION = "1.7.0"
+const VERSION = "1.7.1"
 
 func main() {
 	cli.AppHelpTemplate =

--- a/util/extension.go
+++ b/util/extension.go
@@ -64,7 +64,6 @@ var (
 		"psd",
 		"rar",
 		"rpm",
-		"rst",
 		"rtf",
 		"s7z",
 		"shar",


### PR DESCRIPTION
Part of LIM-9937

We don't actually mark text files, but rather remove it from the non text files list.

