### PR TITLE
Remove head checks

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -56,13 +56,9 @@ func Snapshot(opts *options.Options) (err error) {
 		}
 	}
 
-	var headCommit *object.Commit
-	headCommit, err = provider.getCommit("HEAD")
+	_, err = provider.getCommit("HEAD")
 	if err != nil {
-		return fmt.Errorf("failed to resolved HEAD revision: %v", err)
-	}
-	if headCommit == nil {
-		return nil
+		return fmt.Errorf("failed to resolve HEAD revision: %v", err)
 	}
 
 	var commit *object.Commit
@@ -114,12 +110,6 @@ func Snapshot(opts *options.Options) (err error) {
 }
 
 func (provider *repositoryProvider) getCommit(commitish string) (*object.Commit, error) {
-
-	_, err := provider.repository.Head()
-	if err == plumbing.ErrReferenceNotFound {
-		log.Printf("repository is detected as empty -- nothing to do")
-		return nil, nil
-	}
 
 	hash, err := provider.repository.ResolveRevision(plumbing.Revision(commitish))
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const VERSION = "1.9"
+const VERSION = "1.10"
 
 func main() {
 	cli.AppHelpTemplate =


### PR DESCRIPTION
Related to LIM-16800 - By removing these checks, we'll start to return errors if we find that the repository is empty instead of nil.
This means that the message queue in the extractor will return the message to the queue and read it at a later time, potentially avoiding the race condition.
