### PR TITLE
Add only files that will be snapped in the index file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 **/.DS_STORE
 bin
+gitsnap

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tool to create a git revision snapshot for an existing repository clone.
 
 ```
 NAME:
-   git-snap - 1.14 - Create a git revision snapshot for an existing repository clone. Symbolic link files will be omitted.
+   git-snap - 1.15 - Create a git revision snapshot for an existing repository clone. Symbolic link files will be omitted.
 
 USAGE:
    git-snap --src value --rev value   --out value          [optional flags]
@@ -45,9 +45,9 @@ EXIT CODES:
 ## Examples
 
 ```bash
-git snap --src /var/shared/git/dc-heacth --rev master --out /tmp/dc-heacth-master
-git snap --src /var/shared/git/dc-heacth --rev master --out /tmp/dc-heacth-master --include "**/*.java" --exclude "**/test/**"
-git snap --src /var/shared/git/dc-heacth --rev master --out /tmp/dc-heacth-master --include "**/*.java,pom.xml"
+git-snap --src /var/shared/git/dc-heacth --rev master --out /tmp/dc-heacth-master
+git-snap --src /var/shared/git/dc-heacth --rev master --out /tmp/dc-heacth-master --include "**/*.java" --exclude "**/test/**"
+git-snap --src /var/shared/git/dc-heacth --rev master --out /tmp/dc-heacth-master --include "**/*.java,pom.xml"
 ```
 
 ## Install

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -142,7 +142,7 @@ func (gitSuite *gitTestSuite) verifyIndexFile(
 	}
 
 	gitSuite.Require().Nil(err)
-	gitSuite.Require().EqualValues(fileCount, expectedFileCount, "unexpected files count")
+	gitSuite.Require().EqualValues(expectedFileCount, fileCount, "unexpected files count")
 }
 
 func (gitSuite *gitTestSuite) TestSnapshotForRegularCommit() {
@@ -510,5 +510,5 @@ func (gitSuite *gitTestSuite) TestSnapshotWithIndexPath() {
 	})
 
 	gitSuite.Nil(err)
-	gitSuite.verifyIndexFile(208, indexFilePath)
+	gitSuite.verifyIndexFile(40, indexFilePath)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gitsnap
 
-go 1.14
+go 1.15
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible


### PR DESCRIPTION
Currently, the index file the is created contains all files in the commitish.
This will make sure that the index file will only contain files/directories that are/would be fetched using the same include/ignore patterns