### PR TITLE
Fix ErrorWithCode (de)reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tool to create a git revision snapshot for an existing repository clone.
 
 ```
 NAME:
-   git-snap - 1.19 - Create a git revision snapshot for an existing repository clone. Symbolic link files will be omitted.
+   git-snap - 1.20 - Create a git revision snapshot for an existing repository clone. Symbolic link files will be omitted.
 
 USAGE:
    git-snap --src value --rev value   --out value           [optional flags]

--- a/git/git.go
+++ b/git/git.go
@@ -271,7 +271,7 @@ func (provider *repositoryProvider) dumpFile(repository *git.Repository, name st
 	err = ioutil.WriteFile(targetFilePath, contentsBytes, TARGET_PERMISSIONS)
 	if err != nil {
 		if strings.Contains(err.Error(), "file name too long") {
-			return util.ErrorWithCode{
+			return &util.ErrorWithCode{
 				StatusCode:    util.ERROR_PATH_TOO_LONG,
 				InternalError: err,
 			}, false
@@ -311,10 +311,10 @@ func (provider *repositoryProvider) snapshot(repository *git.Repository, commit 
 
 	tree, err := commit.Tree()
 	if err != nil {
-        return 0, util.ErrorWithCode{
-            StatusCode:    util.ERROR_TREE_NOT_FOUND,
-            InternalError: fmt.Errorf("failed to get tree of commit '%v': %v", commit.Hash, err),
-        }
+		return 0, &util.ErrorWithCode{
+			StatusCode:    util.ERROR_TREE_NOT_FOUND,
+			InternalError: fmt.Errorf("failed to get tree of commit '%v': %v", commit.Hash, err),
+		}
 	}
 	count := 0
 
@@ -369,13 +369,13 @@ func (provider *repositoryProvider) snapshot(repository *git.Repository, commit 
 
 	if err != nil {
 		if errors.Is(err, dotgit.ErrPackfileNotFound) {
-			return 0, util.ErrorWithCode{
+			return 0, &util.ErrorWithCode{
 				StatusCode:    util.ERROR_BAD_CLONE_GIT,
 				InternalError: err,
 			}
 		}
 		if errors.Is(err, plumbing.ErrObjectNotFound) {
-			return 0, util.ErrorWithCode{
+			return 0, &util.ErrorWithCode{
 				StatusCode:    util.ERROR_NO_REVISION,
 				InternalError: err,
 			}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const VERSION = "1.19"
+const VERSION = "1.20"
 
 func main() {
 	cli.AppHelpTemplate =


### PR DESCRIPTION
Turns out the type check wether the error is one that contains a known status code actually checks for a pointer to it, meaning we must return a pointer.
Without it, we returned the error but with the default exit code 1 instead of the actual status code.