### PR TITLE
Handle file names with special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tool to create a git revision snapshot for an existing repository clone.
 
 ```
 NAME:
-   git-snap - 1.20 - Create a git revision snapshot for an existing repository clone. Symbolic link files will be omitted.
+   git-snap - 1.21 - Create a git revision snapshot for an existing repository clone. Symbolic link files will be omitted.
 
 USAGE:
    git-snap --src value --rev value   --out value           [optional flags]

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -130,8 +130,21 @@ func (gitSuite *gitTestSuite) verifyIndexFile(
 
 	scanner := bufio.NewScanner(file)
 	fileCount := 0
+	i := 0
 	for scanner.Scan() {
-		fields := strings.Split(scanner.Text(), "\t")
+		i++
+		lineText := scanner.Text()
+		fields := strings.Split(lineText, "\t")
+
+		if i == 1 {
+			if len(fields) != 3 || fields[0] != "Path" || fields[1] != "BlobId" || fields[2] != "IsFile" {
+				gitSuite.Require().Fail("Index file header line is incorrect", lineText)
+				return
+			}
+
+			continue
+		}
+
 		fileStat, err := os.Stat(gitSuite.outputPath + "/" + fields[0])
 
 		if err == nil {
@@ -510,7 +523,7 @@ func (gitSuite *gitTestSuite) TestSnapshotWithIndexPath() {
 	})
 
 	gitSuite.Nil(err)
-	gitSuite.verifyIndexFile(41, indexFilePath)
+	gitSuite.verifyIndexFile(40, indexFilePath)
 }
 
 func (gitSuite *gitTestSuite) TestSnapshotWithPathsFile() {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -510,7 +510,7 @@ func (gitSuite *gitTestSuite) TestSnapshotWithIndexPath() {
 	})
 
 	gitSuite.Nil(err)
-	gitSuite.verifyIndexFile(40, indexFilePath)
+	gitSuite.verifyIndexFile(41, indexFilePath)
 }
 
 func (gitSuite *gitTestSuite) TestSnapshotWithPathsFile() {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const VERSION = "1.20"
+const VERSION = "1.21"
 
 func main() {
 	cli.AppHelpTemplate =


### PR DESCRIPTION
## What

Use the Golang built-in CSV library to escape special characters in file names automatically

## Why

Some customers (like EA, Shell, and Included Health) have files with special characters like `\n` or `\r` in their names.
Currently, since we're not really writing a CSV this breaks the file format.

Example:

Say the customer has a file called `weird\nname.txt`.\
Right now, the output file will be:

```csv
weird
name.txt <blob_sha> true
```

using the CSV library this becomes:

```csv
"weird
name.txt" <blob_sha> true
```

if we read this using a CSV reader, it should be able to handle this correctly (tested in C#)

Same for the input file list.

## How

Use CSV readers and writers on both ends instead of self-parsing the CSV
