### PR TITLE
Skip non ascii file paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const VERSION = "1.25"
+const VERSION = "1.26"
 
 func main() {
 	cli.AppHelpTemplate =


### PR DESCRIPTION
Skip invalid UTF-8 file paths to avoid "illegal byte sequence" errors when creating target directories for these files. 
This issue often occurs due to the way filenames were initially encoded when they were added to the Git repository. If files were added using a system or tool that interpreted them as ISO-8859-1, trying to decode those paths as UTF-8 strings can result in errors and unexpected behavior.