### PR TITLE
Improved snapshot discrepancy retry logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const VERSION = "1.31"
+const VERSION = "1.32"
 
 func main() {
 	cli.AppHelpTemplate =


### PR DESCRIPTION
Part of LIM-31935

Still seeing some dry-run issues. When they happen, this later causes a MissingCommitException, causing a refetch, etc. As that process can be quite long, im adding a retry logic here before starting the whole refetch flow.
Also, changed a bit the discrepancy check - instead of: dry-run, actual-run, dry-run again. I'm simplifying it to dry-run, actual-run. If numbers are the same, then return successful. Otherwise, retry.